### PR TITLE
スケジュールカードに登場メンバーのアイコンを表示する機能の追加

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,6 @@ module.exports = (phase, { defaultConfig }) => {
   /* config options here */
   return {
     ...defaultConfig,
-    webpack5: true
+    webpack5: true,
   }
 }

--- a/src/components/template/Card/Charactors.tsx
+++ b/src/components/template/Card/Charactors.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface OwnProps {
+    charactorIconSources: string[],
+    children?: React.ReactNode,
+}
+
+type Props = OwnProps;
+
+const Charactors: React.FC<Props> = (props) => {
+  const { charactorIconSources } = props;
+  return(
+    <ul className='w-full flex flex-wrap'>
+      {charactorIconSources.map((iconSource, i) => 
+        <li key={`charactor-icon-${i}`} className='' style={{width: '10%'}}>
+          <img className='rounded-full h-full px-1 py-1 flex-shrink-0' alt={`charactor-${i}`} src={iconSource}/>
+        </li>
+
+      )}
+    </ul>
+  )
+}
+
+export default Charactors;

--- a/src/components/template/Card/Full.tsx
+++ b/src/components/template/Card/Full.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { CardOutLine, CardHeader, CardMedia, CardContents } from './index';
+import { CardOutLine, CardHeader, CardMedia, CardContents, CharactorIcons } from './index';
 import { RoundIconSvg } from 'components/parts/svgIcons';
 
 interface OwnProps {
@@ -11,7 +11,8 @@ interface OwnProps {
   mediaSrc: string,
   mediahref: string,
   onLive?: boolean,
-  children?: React.ReactNode
+  children?: React.ReactNode,
+  charactorIconSources: string[],
 }
 
 type Props = OwnProps;
@@ -25,7 +26,8 @@ const Full: React.FC<Props> = (props) => {
     mediaSrc,
     mediahref,
     children,
-    onLive
+    onLive,
+    charactorIconSources,
   } = props;
   return (
     <CardOutLine>
@@ -45,6 +47,9 @@ const Full: React.FC<Props> = (props) => {
       <CardMedia
         src={mediaSrc}
         href={mediahref}
+      />
+      <CharactorIcons
+        charactorIconSources={charactorIconSources}
       />
       <CardContents>
         {children}

--- a/src/components/template/Card/index.tsx
+++ b/src/components/template/Card/index.tsx
@@ -11,3 +11,5 @@ export { default as CardContents } from './Contents';
 export { default as CardFullTemplate } from './Full';
 
 export { default as CardNews } from './News';
+
+export { default as CharactorIcons } from './Charactors';

--- a/src/lib/Converter.ts
+++ b/src/lib/Converter.ts
@@ -42,6 +42,7 @@ export const VideoScheduleToCardType = (s: VideoSchedule): CardType => {
     mediahref: s.VideoLink,
     title: s.VideoTitle,
     onLive: s.VideoStatus === 2,
+    charactorIconSources: s.Charactors?.map(x => x in streamerDataMap ? (streamerDataMap[x]).youtubeIcon : '').filter(x => x !== '') ?? []
   })
 }
 

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -35,6 +35,7 @@ export interface VideoSchedule {
     Thumbnail: string,
     StartDate: FireStoreTimeStamp,
     Duration?: number,
+    Charactors: string[],
 }
 
 export interface MonthData {


### PR DESCRIPTION
スケジュールカードにその動画で登場するメンバーのアイコンを表示する機能を追加。firestoreのCharactorsに入っているidをもとに表示される