### PR TITLE
fix: 🐛 schedule data length 0 bug fix. bug: array map error

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -56,7 +56,7 @@ export const getStaticProps: GetStaticProps = async () => {
     }
   }
 
-  const cardData = data.response_data.map(x => DayScheduleToCardType(x));
+  const cardData = data.response_data?.map(x => DayScheduleToCardType(x)) ?? [];
 
   const revalidateTime = 1;
 

--- a/src/pages/schedule/[year]/[month]/[day]/index.tsx
+++ b/src/pages/schedule/[year]/[month]/[day]/index.tsx
@@ -99,7 +99,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
     }
   }
 
-  const cardData = data.response_data.map(x => DayScheduleToCardType(x));
+  const cardData = data.response_data?.map(x => DayScheduleToCardType(x)) ?? [];
 
   const revalidateTime = calcRevalidateTime(year, month, day);
 


### PR DESCRIPTION
APIから取得したスケジュール情報が0件だった場合に、array.mapを実行した際にエラーが発生する現象を解消。
0件の対象はArray.mapをせずにからのarrayを返すように変更