### PR TITLE
feat: 🎸 day prev and next navigation change

### DIFF
--- a/src/components/standalone/SchedulesNavigation.tsx
+++ b/src/components/standalone/SchedulesNavigation.tsx
@@ -26,13 +26,8 @@ const SchedulesNavigation: React.FC<Props> = (props) => {
 
   const nextDate = new Date(year, month - 1, day);
   nextDate.setDate(nextDate.getDate() + 1);
-  const today = getNow();
-  const nextIsToday = today.getFullYear() === nextDate.getFullYear()
-    && today.getMonth() === nextDate.getMonth()
-    && today.getDate() === nextDate.getDate();
   
-  const nextNavigation = nextIsToday ? {href: '/'} :
-    {href: '/schedule/[year]/[month]/[day]', as: `/schedule/${nextDate.getFullYear()}/${nextDate.getMonth() + 1}/${nextDate.getDate()}`};
+  const nextNavigation = {href: '/schedule/[year]/[month]/[day]', as: `/schedule/${nextDate.getFullYear()}/${nextDate.getMonth() + 1}/${nextDate.getDate()}`};
 
   return (
     <PrevAndNextNavigations 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,8 @@ import Head from 'next/head'
 import { GetStaticProps } from 'next';
 
 import SchedulesField, { CardType } from 'components/field/Schedules';
-import TodaysPrevNavigation from 'components/standalone/TodaysPrevNavigation';
+
+import SchedulesNavigation from 'components/standalone/SchedulesNavigation';
 
 import { DayScheduleToCardType } from 'lib/Converter';
 import { getNow } from 'lib/DateFunctions';
@@ -23,6 +24,9 @@ type Props = OwnProps;
 
 const Home: React.FC<Props> = (props) => {
   const {
+    year,
+    month,
+    day,
     cardData,
   } = props;
 
@@ -33,7 +37,9 @@ const Home: React.FC<Props> = (props) => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main className='h-full overflow-y-auto'>
-        <TodaysPrevNavigation {...props}/>
+        <SchedulesNavigation year={year} month={month} day={day}>
+          <h1 className='text-xl px-4 text-center'>{year}年{month}月{day}日</h1>
+        </SchedulesNavigation>
         <SchedulesField cardData={cardData} />
       </main>
     </React.Fragment>


### PR DESCRIPTION
prev and next navigation can move after today in day schedule page.

スケジュール表示ページのナビゲーション(ページ上部の＜＞)の挙動を変更
- 本日以後の日付への移動が可能になった
現在日付の前の日から現在日付の日に移動するときにルートへ遷移していた挙動を他の日付への移動と同じ挙動(次の日付に移動する)に変更