### PR TITLE
検索ページのボタンが動かないことがある現象の解消

### DIFF
--- a/app/streaming/search/page.tsx
+++ b/app/streaming/search/page.tsx
@@ -139,7 +139,7 @@ const searchParamsConvert = ({searchParams}: Props): StreamingSearchRequestParam
 
 const fetchData = async(params: StreamingSearchRequestParams) => {
     const req = new StreamingSearchRequest();
-    return await req.Get(params, 1);
+    return await req.Get(params, 0);
 }
 
 const Page = async ({searchParams}: Props) => {

--- a/components/field/StreamingSearchMenu.tsx
+++ b/components/field/StreamingSearchMenu.tsx
@@ -10,6 +10,8 @@ import Stepper from 'components/parts/stepper';
 import MiniCalendar from 'components/standalone/MiniCalendar';
 import { IDate, iDateToString } from 'library/DateFunctions';
 
+import LinkAlways from 'components/parts/link_always';
+
 interface Props {
     memberList: SearchMember[]
     rangeStart: IDate
@@ -372,11 +374,7 @@ const StreamingSearchMenu: React.FC<Props> = ({memberList, rangeStart, rangeEnd}
                 </ListCabinet>
             </div>
             <div id='search-button' className='text-right mt-4'>
-                <Link
-                    href={{
-                        pathname: '/streaming/search',
-                        query: pageValueToLinkQuery(state.pageValue)
-                    }}
+                <LinkAlways
                     className={`
                         inline-block bg-gray-200 rounded
                         px-4 py-2 mx-4
@@ -386,9 +384,11 @@ const StreamingSearchMenu: React.FC<Props> = ({memberList, rangeStart, rangeEnd}
                         `}
                     draggable={false}
                     prefetch={false}
+                    pathname='/streaming/search'
+                    query={pageValueToLinkQuery(state.pageValue)}
                 >
                     検索
-                </ Link>
+                </ LinkAlways>
             </div>
             {
                 state.modalMode !== 'none' ? (

--- a/components/parts/link_always.tsx
+++ b/components/parts/link_always.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import React from 'react';
+
+import Link from 'next/link';
+import { usePathname, useSearchParams, useRouter } from 'next/navigation';
+import { ParsedUrlQueryInput } from 'querystring';
+
+interface SameCheckParams {
+    pathname: string
+    query: ParsedUrlQueryInput
+}
+
+type Props = Omit<React.ComponentProps<typeof Link>, 'href'> & SameCheckParams;
+
+export const isSameLink = (param: SameCheckParams) => {
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    if (pathname !== param.pathname) {
+        return false;
+    }
+    const queryKeys = Object.keys(param.query);
+
+    for(const s of queryKeys) {
+        const searchValue = searchParams.get(s);
+        if(searchValue === null) {
+            return false;
+        }
+
+        const queryValue = param.query[s];
+
+        switch(typeof queryValue) {
+            case 'string': {
+                if(queryValue !== searchValue) {
+                    return false;
+                }
+                break;
+            }
+            case 'number': {
+                const vton = parseInt(searchValue);
+                if(isNaN(vton)) return false;
+                if(vton !== queryValue) return false;
+                break;
+            }
+            case 'boolean': {
+                if(searchValue !== 'true' && searchValue !== 'false') return false;
+                if(queryValue !== (searchValue === 'true')) return false;
+                break;
+            }
+            default: {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+const LinkAlways: React.FC<Props> = (props) => {
+    const router = useRouter();
+    if(isSameLink(props)) {
+        const clickButton = () => {
+            console.log('refresh');
+            router.refresh();
+        }
+        return (
+            <button onClick={clickButton} className={props.className} >
+                {props.children}
+            </button>
+        )
+    }
+
+    return (
+        <Link
+            href={{
+                pathname: props.pathname,
+                query: props.query
+            }}
+            className={props.className}
+            draggable={props.draggable}
+            prefetch={props.prefetch}
+        >
+            {props.children}
+        </ Link>
+    )
+}
+
+export default LinkAlways;

--- a/components/parts/link_always.tsx
+++ b/components/parts/link_always.tsx
@@ -13,7 +13,7 @@ interface SameCheckParams {
 
 type Props = Omit<React.ComponentProps<typeof Link>, 'href'> & SameCheckParams;
 
-export const isSameLink = (param: SameCheckParams) => {
+export const useIsSameLink = (param: SameCheckParams) => {
     const pathname = usePathname();
     const searchParams = useSearchParams();
 
@@ -59,7 +59,7 @@ export const isSameLink = (param: SameCheckParams) => {
 
 const LinkAlways: React.FC<Props> = (props) => {
     const router = useRouter();
-    if(isSameLink(props)) {
+    if(useIsSameLink(props)) {
         const clickButton = () => {
             console.log('refresh');
             router.refresh();


### PR DESCRIPTION
検索ページを表示したときのURLと検索ボタンを押したときに遷移する先のURLが同じ場合に検索ボタンを推してもなんの動作もしない状態だった。
ユーザは何が起きているか、何も起きていないのか、なぜ動かないのかを判断できないので、同じページにアクセスする場合でもLinkの挙動を行うように修正した。
同じページへのアクセスの場合にはrouterのrefreshが行われる。